### PR TITLE
feat: add some examples of topx queries for metrics and events

### DIFF
--- a/queries_top/queries_events_top.gql
+++ b/queries_top/queries_events_top.gql
@@ -1,0 +1,18 @@
+query EventsTopIPCountryCGNAT {
+ httpEvents(
+   limit: 10,
+   filter: {
+     tsRange: {begin:"2023-03-25T08:36:10", end:"2023-03-27T11:36:10"}
+   },
+   aggregate: {count: remoteAddress}
+   groupBy: [remoteAddress, geolocAsn, geolocCountryName, source]
+   orderBy: [count_DESC]
+   )
+ {
+   remoteAddress
+   geolocAsn
+   geolocCountryName
+   source
+   count
+ }
+}

--- a/queries_top/queries_metrics_top.gql
+++ b/queries_top/queries_metrics_top.gql
@@ -1,0 +1,16 @@
+query Top10Host {
+  httpMetrics(
+    limit: 10, 
+    filter: {
+      tsRange: {begin:"2023-03-23T18:25:00", end:"2023-03-23T19:25:00"}
+    },
+    aggregate: {count: host}
+    groupBy: [host]
+    orderBy: [count_DESC]
+  	) 
+  {	
+    host
+    count
+    dataTransferredTotal
+  }
+}


### PR DESCRIPTION
Adding the first queries for making topX searches with the new GQL api.

Features:

- Add some initial queries for topX searches on events and metrics api.

